### PR TITLE
Integrate mindoc module

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -15,7 +15,7 @@
 	<project path="mind-compiler" name="mind-compiler" remote="github-mind-tools" sync-c="true" revision="master" />
 
 	<!-- Git projects from github-mind4se remote -->
-		<!-- To be completed with Mind4SE plugins -->
+	<project path="mindoc" name="mindoc" remote="github-mind4se" sync-c="true" revision="master" />
 
 	<!-- MIND-Tools Assembly pom, from github-mind-tools remote -->
 	<project path="." name="mind-tools" remote="github-mind-tools" sync-c="true" revision="master" />


### PR DESCRIPTION
# Integrate mindoc module
## Note

This Pull Request is related to the "mind-tools" one providing necessary according Maven aggregation/integration:
https://github.com/MIND-Tools/mind-tools/pull/2
## Contribution

Add Mind4SE's mindoc version to the release.

It now works as a compiler plugin (simplifying maintenance), supports SVG graphical architecture supports, inheritance documentation, C syntax coloring, packages indexing fixing, Windows bugfixes, and more.

The resulting package will include the mindoc scripts in bin/, the mindoc jar and commons-io in ext/, the example in examples/doc, HTML resources in resources/, and the README_DOC at the root of the package.
